### PR TITLE
Embed templates

### DIFF
--- a/plexlib/CMakeLists.txt
+++ b/plexlib/CMakeLists.txt
@@ -24,3 +24,11 @@ target_sources(plexlib
 )
 target_include_directories(plexlib PUBLIC source)
 target_compile_features(plexlib PUBLIC cxx_std_17)
+
+file(READ templates/template.hpp PLEXLIB_HEADER_TEMPLATE_CONTENT)
+file(READ templates/template.cpp PLEXLIB_CODE_TEMPLATE_CONTENT)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+configure_file(
+    templates/template-holder.hpp
+    template-holder.hpp
+)

--- a/plexlib/source/template/template.cpp
+++ b/plexlib/source/template/template.cpp
@@ -7,6 +7,7 @@
 #include <set>
 #include <sstream>
 
+#include <template-holder.hpp>
 #include <utils.hpp>
 
 void ReplaceErrorName(std::string& content, const std::string& name)
@@ -58,7 +59,7 @@ void SaveFile(const std::string& content, const std::string& path)
 
 std::string TemplateHeader(FileNode file, std::string header, std::string name)
 {
-    std::string content = ReadFile("template.hpp");
+    std::string content = header_template;
 
     ReplaceName(content, name);
     std::string errorName = ReplaceTokens(content, file);
@@ -73,7 +74,7 @@ void TemplateBody(FileNode file,
                   std::string code,
                   std::string name)
 {
-    std::string content = ReadFile("template.cpp");
+    std::string content = code_template;
 
     ReplaceErrorName(content, errorName);
     ReplaceName(content, name);

--- a/plexlib/templates/template-holder.hpp
+++ b/plexlib/templates/template-holder.hpp
@@ -1,0 +1,4 @@
+const char* const header_template =
+    R"iOv37132Zu(${PLEXLIB_HEADER_TEMPLATE_CONTENT})iOv37132Zu";
+const char* const code_template =
+    R"iOv37132Zu(${PLEXLIB_CODE_TEMPLATE_CONTENT})iOv37132Zu";

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -12,14 +12,3 @@ add_executable(plextest
 )
 target_link_libraries(plextest PUBLIC plexlib)
 target_compile_features(plexlib PUBLIC cxx_std_17)
-
-configure_file(
-    ../plexlib/templates/template.hpp
-    template.hpp
-    COPYONLY
-)
-configure_file(
-    ../plexlib/templates/template.cpp
-    template.cpp
-    COPYONLY
-)


### PR DESCRIPTION
Closes #106 - Executables have to know about plexlib's template file dependency.
Closes #107 - Executables fail if current working directory isn't the executable's directory.