### PR TITLE
Check lexer name

### DIFF
--- a/plexlib/source/plexlib.cpp
+++ b/plexlib/source/plexlib.cpp
@@ -20,8 +20,26 @@ void PrintUsage(std::ostream& out)
         << "Note: Output file and lexer name are based on input file name.\n";
 }
 
-bool IsValidLexerName(const std::string& /*name*/)
+bool IsValidLexerName(const std::string& name)
 {
+    if (name.size() == 0)
+    {
+        return false;
+    }
+
+    if (name[0] != '_' && !isalpha(name[0]))
+    {
+        return false;
+    }
+
+    for (const auto& c : name)
+    {
+        if (c != '_' && !isalnum(c))
+        {
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -50,7 +68,7 @@ int PlexMain(std::vector<std::string>& args,
 
     if (!IsValidLexerName(lexerName))
     {
-        std::cerr << "File generates lexer named `" << lexerName
+        err << "File generates lexer named `" << lexerName
                   << "` which is not a valid identifier. Rename the file to be "
                      "a valid C++ identifier.";
         return bad_lexer_name;

--- a/plexlib/source/plexlib.cpp
+++ b/plexlib/source/plexlib.cpp
@@ -20,6 +20,11 @@ void PrintUsage(std::ostream& out)
         << "Note: Output file and lexer name are based on input file name.\n";
 }
 
+bool IsValidLexerName(const std::string& /*name*/)
+{
+    return true;
+}
+
 int PlexMain(std::vector<std::string>& args,
              std::ostream& out,
              std::ostream& err)
@@ -42,6 +47,14 @@ int PlexMain(std::vector<std::string>& args,
     header.replace_extension(".hpp");
     code.replace_extension(".cpp");
     std::string lexerName = source.filename().stem().string();
+
+    if (!IsValidLexerName(lexerName))
+    {
+        std::cerr << "File generates lexer named `" << lexerName
+                  << "` which is not a valid identifier. Rename the file to be "
+                     "a valid C++ identifier.";
+        return bad_lexer_name;
+    }
 
     try
     {

--- a/plexlib/source/plexlib.cpp
+++ b/plexlib/source/plexlib.cpp
@@ -69,8 +69,8 @@ int PlexMain(std::vector<std::string>& args,
     if (!IsValidLexerName(lexerName))
     {
         err << "File generates lexer named `" << lexerName
-                  << "` which is not a valid identifier. Rename the file to be "
-                     "a valid C++ identifier.";
+            << "` which is not a valid C++ identifier. Rename the file to be "
+               "a valid C++ identifier.\n";
         return bad_lexer_name;
     }
 

--- a/plexlib/source/plexlib.hpp
+++ b/plexlib/source/plexlib.hpp
@@ -10,8 +10,9 @@ constexpr int bad_usage = 1;
 constexpr int help_invoked = 2;
 
 constexpr int unreadable_file = 3;
+constexpr int bad_lexer_name = 4;
 
-constexpr int bad_lexer = 4;
+constexpr int bad_lexer = 5;
 
 constexpr int unknown_fault = 99;
 

--- a/unit-tests/source/test_parameters.cpp
+++ b/unit-tests/source/test_parameters.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Parameters: Extra parameters")
 
 TEST_CASE("Parameters: Nonexistent file")
 {
-    std::stringstream out, err, base;
+    std::stringstream out, err;
     std::filesystem::path inputFile(
         "z:/path/to/file/that/doesn't/exist/nonexistent.txt");
     inputFile.make_preferred();
@@ -61,7 +61,10 @@ TEST_CASE("Parameters: Nonexistent file")
 
 TEST_CASE("Parameters: File with bad identifier")
 {
-    std::stringstream out, err, base;
+    std::stringstream out, err;
+    std::string base =
+        "File generates lexer named `c++` which is not a valid C++ identifier. "
+        "Rename the file to be a valid C++ identifier.\n";
     std::filesystem::path inputFile("z:/c++.txt");
     inputFile.make_preferred();
     std::vector<std::string> params = { inputFile.string() };
@@ -70,5 +73,5 @@ TEST_CASE("Parameters: File with bad identifier")
 
     CHECK(bad_lexer_name == result);
     CHECK("" == out.str());
-    CHECK("Lexer name `c++` is not a valid identifier" == err.str());
+    CHECK(base == err.str());
 }

--- a/unit-tests/source/test_parameters.cpp
+++ b/unit-tests/source/test_parameters.cpp
@@ -47,7 +47,8 @@ TEST_CASE("Parameters: Extra parameters")
 TEST_CASE("Parameters: Nonexistent file")
 {
     std::stringstream out, err, base;
-    std::filesystem::path inputFile("z:/path/to/file/that/doesn't/exist/.txt");
+    std::filesystem::path inputFile(
+        "z:/path/to/file/that/doesn't/exist/nonexistent.txt");
     inputFile.make_preferred();
     std::vector<std::string> params = { inputFile.string() };
 

--- a/unit-tests/source/test_parameters.cpp
+++ b/unit-tests/source/test_parameters.cpp
@@ -57,3 +57,17 @@ TEST_CASE("Parameters: Nonexistent file")
     CHECK("" == out.str());
     CHECK("Unable to read file " + inputFile.string() + "\n" == err.str());
 }
+
+TEST_CASE("Parameters: File with bad identifier")
+{
+    std::stringstream out, err, base;
+    std::filesystem::path inputFile("z:/c++.txt");
+    inputFile.make_preferred();
+    std::vector<std::string> params = { inputFile.string() };
+
+    int result = PlexMain(params, out, err);
+
+    CHECK(bad_lexer_name == result);
+    CHECK("" == out.str());
+    CHECK("Lexer name `c++` is not a valid identifier" == err.str());
+}


### PR DESCRIPTION
Closes #98 - Plexiglass doesn't handle input file names being invalid c++ identifiers.