### PR TITLE
Internal names

### DIFF
--- a/integration-tests/basic-test/base.txt
+++ b/integration-tests/basic-test/base.txt
@@ -12,4 +12,4 @@
 
 9: FiftyToken 
 
-9: PLEXIGLASS_EOF
+9: __eof__

--- a/integration-tests/main.cpp
+++ b/integration-tests/main.cpp
@@ -17,7 +17,7 @@ void RunLexer(std::string inputPath, std::string outputPath)
 
     std::ofstream out(outputPath);
 
-    while (lex.PeekToken() != TokenType::PLEXIGLASS_EOF)
+    while (lex.PeekToken() != TokenType::__eof__)
     {
         out << lex.PeekLine() << ": "
             << ToString(lex.PeekToken(), lex.PeekText()) << "\n";

--- a/plexlib/source/template/template.cpp
+++ b/plexlib/source/template/template.cpp
@@ -237,10 +237,10 @@ std::tuple<std::string, std::string> ReplaceTokens(std::string& content,
     std::set<std::string> tokenNames;
     GetTokenNames(file, tokenNames);
 
-    std::string errorName = "PLEXIGLASS_NO_MATCH_TOKEN";
+    std::string errorName = "__jam__";
     tokenNames.insert(errorName);
 
-    std::string eofName = "PLEXIGLASS_EOF";
+    std::string eofName = "__eof__";
     tokenNames.insert(eofName);
 
     std::stringstream names;

--- a/unit-tests/test-files/template/debug-base.cpp
+++ b/unit-tests/test-files/template/debug-base.cpp
@@ -61,7 +61,7 @@ std::vector<Rule> GetRules()
 
     rules.emplace_back(LexerState::__initial__, "cat", LexerState::__initial__, TokenType::CatToken, true, 0);
     rules.emplace_back(LexerState::__initial__, "dog", LexerState::__initial__, TokenType::DogToken, true, 0);
-    rules.emplace_back(LexerState::__initial__, "\\s+", LexerState::__initial__, TokenType::PLEXIGLASS_EOF, false, 0);
+    rules.emplace_back(LexerState::__initial__, "\\s+", LexerState::__initial__, TokenType::__eof__, false, 0);
 
     return rules;
 }
@@ -83,11 +83,11 @@ std::string ToString(TokenType type, const std::string& text)
     case TokenType::DogToken:
         str = "DogToken";
         break;
-    case TokenType::PLEXIGLASS_EOF:
-        str = "PLEXIGLASS_EOF";
+    case TokenType::__eof__:
+        str = "__eof__";
         break;
-    case TokenType::PLEXIGLASS_NO_MATCH_TOKEN:
-        str = "PLEXIGLASS_NO_MATCH_TOKEN";
+    case TokenType::__jam__:
+        str = "__jam__";
         break;
     default:
             throw std::exception("Unrecognized token type in ToString()");
@@ -163,7 +163,7 @@ bool debug::ShiftHelper()
 {
     if (m_view.empty())
     {
-        m_type = TokenType::PLEXIGLASS_EOF;
+        m_type = TokenType::__eof__;
         m_text = "";
         return true;
     }
@@ -225,7 +225,7 @@ bool debug::ShiftHelper()
     }
     else
     {
-        m_type = TokenType::PLEXIGLASS_NO_MATCH_TOKEN;
+        m_type = TokenType::__jam__;
         m_text = std::string(1, m_view[0]);
         m_view.remove_prefix(1);
         return true;

--- a/unit-tests/test-files/template/debug-base.hpp
+++ b/unit-tests/test-files/template/debug-base.hpp
@@ -10,8 +10,8 @@ enum class TokenType
 {
     CatToken,
     DogToken,
-    PLEXIGLASS_EOF,
-    PLEXIGLASS_NO_MATCH_TOKEN,
+    __eof__,
+    __jam__,
 };
 
 std::string ToString(TokenType type, const std::string& text);

--- a/unit-tests/test-files/template/full-base.cpp
+++ b/unit-tests/test-files/template/full-base.cpp
@@ -60,9 +60,9 @@ std::vector<Rule> GetRules()
 {
     std::vector<Rule> rules;
 
-    rules.emplace_back(LexerState::__initial__, "1st", LexerState::__initial__, TokenType::PLEXIGLASS_EOF, false, 1);
+    rules.emplace_back(LexerState::__initial__, "1st", LexerState::__initial__, TokenType::__eof__, false, 1);
     rules.emplace_back(LexerState::__initial__, "2nd", LexerState::other_state, TokenType::secondToken, true, -1);
-    rules.emplace_back(LexerState::other_state, "3rd", LexerState::__initial__, TokenType::PLEXIGLASS_EOF, false, 0);
+    rules.emplace_back(LexerState::other_state, "3rd", LexerState::__initial__, TokenType::__eof__, false, 0);
 
     return rules;
 }
@@ -78,11 +78,11 @@ std::string ToString(TokenType type, const std::string& text)
     std::string str;
     switch (type)
     {
-    case TokenType::PLEXIGLASS_EOF:
-        str = "PLEXIGLASS_EOF";
+    case TokenType::__eof__:
+        str = "__eof__";
         break;
-    case TokenType::PLEXIGLASS_NO_MATCH_TOKEN:
-        str = "PLEXIGLASS_NO_MATCH_TOKEN";
+    case TokenType::__jam__:
+        str = "__jam__";
         break;
     case TokenType::secondToken:
         str = "secondToken";
@@ -161,7 +161,7 @@ bool full::ShiftHelper()
 {
     if (m_view.empty())
     {
-        m_type = TokenType::PLEXIGLASS_EOF;
+        m_type = TokenType::__eof__;
         m_text = "";
         return true;
     }
@@ -223,7 +223,7 @@ bool full::ShiftHelper()
     }
     else
     {
-        m_type = TokenType::PLEXIGLASS_NO_MATCH_TOKEN;
+        m_type = TokenType::__jam__;
         m_text = std::string(1, m_view[0]);
         m_view.remove_prefix(1);
         return true;

--- a/unit-tests/test-files/template/full-base.hpp
+++ b/unit-tests/test-files/template/full-base.hpp
@@ -8,8 +8,8 @@ enum class LexerState;
 
 enum class TokenType
 {
-    PLEXIGLASS_EOF,
-    PLEXIGLASS_NO_MATCH_TOKEN,
+    __eof__,
+    __jam__,
     secondToken,
 };
 

--- a/unit-tests/test-files/template/simple-base.cpp
+++ b/unit-tests/test-files/template/simple-base.cpp
@@ -61,7 +61,7 @@ std::vector<Rule> GetRules()
 
     rules.emplace_back(LexerState::__initial__, "cat", LexerState::__initial__, TokenType::CatToken, true, 0);
     rules.emplace_back(LexerState::__initial__, "dog", LexerState::__initial__, TokenType::DogToken, true, 0);
-    rules.emplace_back(LexerState::__initial__, "\\s+", LexerState::__initial__, TokenType::PLEXIGLASS_EOF, false, 0);
+    rules.emplace_back(LexerState::__initial__, "\\s+", LexerState::__initial__, TokenType::__eof__, false, 0);
 
     return rules;
 }
@@ -83,11 +83,11 @@ std::string ToString(TokenType type, const std::string& text)
     case TokenType::DogToken:
         str = "DogToken";
         break;
-    case TokenType::PLEXIGLASS_EOF:
-        str = "PLEXIGLASS_EOF";
+    case TokenType::__eof__:
+        str = "__eof__";
         break;
-    case TokenType::PLEXIGLASS_NO_MATCH_TOKEN:
-        str = "PLEXIGLASS_NO_MATCH_TOKEN";
+    case TokenType::__jam__:
+        str = "__jam__";
         break;
     default:
             throw std::exception("Unrecognized token type in ToString()");
@@ -163,7 +163,7 @@ bool simple::ShiftHelper()
 {
     if (m_view.empty())
     {
-        m_type = TokenType::PLEXIGLASS_EOF;
+        m_type = TokenType::__eof__;
         m_text = "";
         return true;
     }
@@ -225,7 +225,7 @@ bool simple::ShiftHelper()
     }
     else
     {
-        m_type = TokenType::PLEXIGLASS_NO_MATCH_TOKEN;
+        m_type = TokenType::__jam__;
         m_text = std::string(1, m_view[0]);
         m_view.remove_prefix(1);
         return true;

--- a/unit-tests/test-files/template/simple-base.hpp
+++ b/unit-tests/test-files/template/simple-base.hpp
@@ -10,8 +10,8 @@ enum class TokenType
 {
     CatToken,
     DogToken,
-    PLEXIGLASS_EOF,
-    PLEXIGLASS_NO_MATCH_TOKEN,
+    __eof__,
+    __jam__,
 };
 
 std::string ToString(TokenType type, const std::string& text);


### PR DESCRIPTION
Closes #143 - Rename PLEXIGLASS_EOF and PLEXIGLASS_NO_MATCH_TOKEN to double-underscore names.